### PR TITLE
fix ban feature

### DIFF
--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -91,8 +91,7 @@ export class GuildBans {
       null,
       true
     )
-
-    if (res.status !== 204) throw new Error('Failed to Add Guild Ban')
+    if (res.response.status !== 204) throw new Error('Failed to Add Guild Ban')
   }
 
   /**
@@ -108,7 +107,7 @@ export class GuildBans {
       true
     )
 
-    if (res.status !== 204) return false
+    if (res.response.status !== 204) return false
     else return true
   }
 }


### PR DESCRIPTION
when use ban, module will raise error at everytime. this commit fix it.

----
### What was wrong?
+ `res.status` is always undefined and it makes raise error everytime. need to use `res.response.status`