### PR TITLE
feat(decorators): added support for decorated events and commands

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -12,13 +12,13 @@ export {
   CommandsManager,
   CategoriesManager
 } from './src/models/command.ts'
-export type { CommandContext } from './src/models/command.ts'
+export type { CommandContext, CommandOptions } from './src/models/command.ts'
 export {
   Extension,
   ExtensionCommands,
   ExtensionsManager
 } from './src/models/extensions.ts'
-export { CommandClient } from './src/models/commandClient.ts'
+export { CommandClient, command } from './src/models/commandClient.ts'
 export type { CommandClientOptions } from './src/models/commandClient.ts'
 export { BaseManager } from './src/managers/base.ts'
 export { BaseChildManager } from './src/managers/baseChild.ts'

--- a/src/gateway/handlers/ready.ts
+++ b/src/gateway/handlers/ready.ts
@@ -9,6 +9,7 @@ export const ready: GatewayEventHandler = async (
 ) => {
   await gateway.client.guilds.flush()
 
+  await gateway.client.users.set(d.user.id, d.user)
   gateway.client.user = new User(gateway.client, d.user)
   gateway.sessionID = d.session_id
   gateway.debug(`Received READY. Session: ${gateway.sessionID}`)

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -139,21 +139,6 @@ export class Client extends EventEmitter {
     this.emit('debug', `[${tag}] ${msg}`)
   }
 
-  /**
-   * EXPERIMENTAL Decorators support for listening to events.
-   * @param event Event name to listen for
-   */
-  event(event: string): CallableFunction {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const parent = this
-    return function (
-      target: { [name: string]: CallableFunction },
-      prop: string
-    ) {
-      parent.addListener(event, target[prop] as (...args: any[]) => any)
-    }
-  }
-
   // TODO(DjDeveloperr): Implement this
   // fetchApplication(): Promise<Application>
 

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -11,6 +11,7 @@ import { ClientPresence } from '../structures/presence.ts'
 import { EmojisManager } from '../managers/emojis.ts'
 import { ActivityGame, ClientActivity } from '../types/presence.ts'
 import { ClientEvents } from '../gateway/handlers/index.ts'
+import { Extension } from './extensions.ts'
 
 /** Some Client Options to modify behaviour */
 export interface ClientOptions {
@@ -181,7 +182,7 @@ export class Client extends EventEmitter {
 }
 
 export function event(name?: string) {
-  return function (client: Client, prop: string) {
+  return function (client: Client | Extension, prop: string) {
     const listener = ((client as unknown) as {
       [name: string]: (...args: any[]) => any
     })[prop]

--- a/src/models/command.ts
+++ b/src/models/command.ts
@@ -5,6 +5,7 @@ import { User } from '../structures/user.ts'
 import { Collection } from '../utils/collection.ts'
 import { CommandClient } from './commandClient.ts'
 import { Extension } from './extensions.ts'
+import { parse } from 'https://deno.land/x/mutil@0.1.2/mod.ts'
 
 export interface CommandContext {
   /** The Client object */
@@ -29,9 +30,9 @@ export interface CommandContext {
   guild?: Guild
 }
 
-export class Command {
+export interface CommandOptions {
   /** Name of the Command */
-  name: string = ''
+  name?: string
   /** Description of the Command */
   description?: string
   /** Category of the Command */
@@ -65,6 +66,27 @@ export class Command {
   /** Whether the Command can only be used in Bot's DMs (if allowed) */
   dmOnly?: boolean
   /** Whether the Command can only be used by Bot Owners */
+  ownerOnly?: boolean
+}
+
+export class Command implements CommandOptions {
+  name: string = ''
+  description?: string
+  category?: string
+  aliases?: string | string[]
+  extension?: Extension
+  usage?: string | string[]
+  examples?: string | string[]
+  args?: number | boolean | string[]
+  permissions?: string | string[]
+  userPermissions?: string | string[]
+  botPermissions?: string | string[]
+  roles?: string | string[]
+  whitelistedGuilds?: string | string[]
+  whitelistedChannels?: string | string[]
+  whitelistedUsers?: string | string[]
+  guildOnly?: boolean
+  dmOnly?: boolean
   ownerOnly?: boolean
 
   /** Method executed before executing actual command. Returns bool value - whether to continue or not (optional) */
@@ -418,7 +440,8 @@ export const parseCommand = (
 ): ParsedCommand => {
   let content = msg.content.slice(prefix.length)
   if (client.spacesAfterPrefix === true) content = content.trim()
-  const args = content.split(client.betterArgs === true ? /[\S\s]*/ : / +/)
+  const args = parse(content)._.map((e) => e.toString())
+
   const name = args.shift() as string
   const argString = content.slice(name.length).trim()
 

--- a/src/models/command.ts
+++ b/src/models/command.ts
@@ -61,6 +61,8 @@ export interface CommandOptions {
   whitelistedChannels?: string | string[]
   /** Whitelisted Users. Command can be executed only by these Users (List or one of IDs) */
   whitelistedUsers?: string | string[]
+  /** Whether the Command can only be used in NSFW channel or not */
+  nsfw?: boolean
   /** Whether the Command can only be used in Guild (if allowed in DMs) */
   guildOnly?: boolean
   /** Whether the Command can only be used in Bot's DMs (if allowed) */
@@ -85,6 +87,7 @@ export class Command implements CommandOptions {
   whitelistedGuilds?: string | string[]
   whitelistedChannels?: string | string[]
   whitelistedUsers?: string | string[]
+  nsfw?: boolean
   guildOnly?: boolean
   dmOnly?: boolean
   ownerOnly?: boolean
@@ -250,6 +253,11 @@ export class CommandBuilder extends Command {
 
   setGuildOnly(value: boolean = true): CommandBuilder {
     this.guildOnly = value
+    return this
+  }
+
+  setNSFW(value: boolean = true): CommandBuilder {
+    this.nsfw = value
     return this
   }
 

--- a/src/models/commandClient.ts
+++ b/src/models/commandClient.ts
@@ -1,4 +1,5 @@
 import { Message } from '../structures/message.ts'
+import { GuildTextChannel } from '../structures/textChannel.ts'
 import { awaitSync } from '../utils/mixedPromise.ts'
 import { Client, ClientOptions } from './client.ts'
 import {
@@ -276,6 +277,13 @@ export class CommandClient extends Client implements CommandClientOptions {
       msg.guild !== undefined
     )
       return this.emit('commandDmOnly', ctx, command)
+
+    if (
+      command.nsfw === true &&
+      (msg.guild === undefined ||
+        ((msg.channel as unknown) as GuildTextChannel).nsfw !== true)
+    )
+      return this.emit('commandNSFW', ctx, command)
 
     const allPermissions =
       command.permissions !== undefined

--- a/src/models/commandClient.ts
+++ b/src/models/commandClient.ts
@@ -164,7 +164,7 @@ export class CommandClient extends Client implements CommandClientOptions {
     if (typeof prefix !== 'string') return
 
     const parsed = parseCommand(this, msg, prefix)
-    const command = this.commands.find(parsed.name)
+    const command = this.commands.fetch(parsed)
 
     if (command === undefined) return
     const category =
@@ -361,6 +361,8 @@ export function command(options?: CommandOptions) {
     })[name]
 
     if (options !== undefined) Object.assign(command, options)
+
+    if (target instanceof Extension) command.extension = target
 
     if (target._decoratedCommands === undefined) target._decoratedCommands = {}
     target._decoratedCommands[command.name] = command

--- a/src/models/commandClient.ts
+++ b/src/models/commandClient.ts
@@ -98,6 +98,7 @@ export class CommandClient extends Client implements CommandClientOptions {
       Object.values(this._decoratedCommands).forEach((entry) => {
         this.commands.add(entry)
       })
+      this._decoratedCommands = undefined
     }
 
     this.on(
@@ -361,13 +362,7 @@ export function command(options?: CommandOptions) {
 
     if (options !== undefined) Object.assign(command, options)
 
-    if (target instanceof CommandClient) {
-      if (target._decoratedCommands === undefined)
-        target._decoratedCommands = {}
-      target._decoratedCommands[command.name] = command
-    } else {
-      if (target._decorated === undefined) target._decorated = {}
-      target._decorated[command.name] = command
-    }
+    if (target._decoratedCommands === undefined) target._decoratedCommands = {}
+    target._decoratedCommands[command.name] = command
   }
 }

--- a/src/models/extensions.ts
+++ b/src/models/extensions.ts
@@ -69,9 +69,15 @@ export class Extension {
   commands: ExtensionCommands = new ExtensionCommands(this)
   /** Events registered by this Extension */
   events: { [name: string]: (...args: any[]) => {} } = {}
+  _decorated?: { [name: string]: Command }
 
   constructor(client: CommandClient) {
     this.client = client
+    if (this._decorated !== undefined) {
+      Object.entries(this._decorated).forEach((entry) => {
+        this.commands.add(entry[1])
+      })
+    }
   }
 
   /** Listen for an Event through Extension. */

--- a/src/models/extensions.ts
+++ b/src/models/extensions.ts
@@ -67,6 +67,8 @@ export class Extension {
   description?: string
   /** Extensions's Commands Manager */
   commands: ExtensionCommands = new ExtensionCommands(this)
+  /** Sub-Prefix to be used for ALL of Extenion's Commands. */
+  subPrefix?: string
   /** Events registered by this Extension */
   events: { [name: string]: (...args: any[]) => {} } = {}
 
@@ -77,6 +79,7 @@ export class Extension {
     this.client = client
     if (this._decoratedCommands !== undefined) {
       Object.entries(this._decoratedCommands).forEach((entry) => {
+        entry[1].extension = this
         this.commands.add(entry[1])
       })
       this._decoratedCommands = undefined

--- a/src/models/extensions.ts
+++ b/src/models/extensions.ts
@@ -69,14 +69,27 @@ export class Extension {
   commands: ExtensionCommands = new ExtensionCommands(this)
   /** Events registered by this Extension */
   events: { [name: string]: (...args: any[]) => {} } = {}
-  _decorated?: { [name: string]: Command }
+
+  _decoratedCommands?: { [name: string]: Command }
+  _decoratedEvents?: { [name: string]: (...args: any[]) => any }
 
   constructor(client: CommandClient) {
     this.client = client
-    if (this._decorated !== undefined) {
-      Object.entries(this._decorated).forEach((entry) => {
+    if (this._decoratedCommands !== undefined) {
+      Object.entries(this._decoratedCommands).forEach((entry) => {
         this.commands.add(entry[1])
       })
+      this._decoratedCommands = undefined
+    }
+
+    if (
+      this._decoratedEvents !== undefined &&
+      Object.keys(this._decoratedEvents).length !== 0
+    ) {
+      Object.entries(this._decoratedEvents).forEach((entry) => {
+        this.listen(entry[0], entry[1])
+      })
+      this._decoratedEvents = undefined
     }
   }
 

--- a/src/structures/guildVoiceChannel.ts
+++ b/src/structures/guildVoiceChannel.ts
@@ -42,7 +42,7 @@ export class VoiceChannel extends Channel {
         if (state.channel?.id !== this.id) return
         this.client.removeListener('voiceStateAdd', onVoiceStateAdd)
         done++
-        if (done >= 2) resolve(vcdata)
+        if (done >= 2) resolve((vcdata as unknown) as VoiceServerUpdateData)
       }
 
       const onVoiceServerUpdate = (data: VoiceServerUpdateData): void => {

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -1,7 +1,6 @@
 import { Base } from './base.ts'
 import {
   Attachment,
-  ChannelMention,
   MessageActivity,
   MessageApplication,
   MessageOption,

--- a/src/test/class.ts
+++ b/src/test/class.ts
@@ -1,0 +1,62 @@
+import {
+  CommandClient,
+  event,
+  Intents,
+  command,
+  CommandContext,
+  Extension
+} from '../../mod.ts'
+import { TOKEN } from './config.ts'
+
+class MyClient extends CommandClient {
+  constructor() {
+    super({
+      prefix: '!',
+      caseSensitive: false
+    })
+  }
+
+  @event()
+  ready(): void {
+    console.log(`Logged in as ${this.user?.tag}!`)
+  }
+
+  @command({
+    aliases: 'pong'
+  })
+  Ping(ctx: CommandContext): void {
+    ctx.message.reply('Pong!')
+  }
+}
+
+class VCExtension extends Extension {
+  @command()
+  async join(ctx: CommandContext): Promise<void> {
+    const userVS = await ctx.guild?.voiceStates.get(ctx.author.id)
+    if (userVS === undefined) {
+      ctx.message.reply("You're not in VC.")
+      return
+    }
+    await userVS.channel?.join()
+    ctx.message.reply(`Joined VC channel - ${userVS.channel?.name}!`)
+  }
+
+  @command()
+  async leave(ctx: CommandContext): Promise<void> {
+    const userVS = await ctx.guild?.voiceStates.get(
+      (ctx.client.user?.id as unknown) as string
+    )
+    if (userVS === undefined) {
+      ctx.message.reply("I'm not in VC.")
+      return
+    }
+    userVS.channel?.leave()
+    ctx.message.reply(`Left VC channel - ${userVS.channel?.name}!`)
+  }
+}
+
+const client = new MyClient()
+
+client.extensions.load(VCExtension)
+
+client.connect(TOKEN, Intents.All)

--- a/src/test/class.ts
+++ b/src/test/class.ts
@@ -12,7 +12,7 @@ import { TOKEN } from './config.ts'
 class MyClient extends CommandClient {
   constructor() {
     super({
-      prefix: '!',
+      prefix: ['!', '!!'],
       caseSensitive: false
     })
   }

--- a/src/test/class.ts
+++ b/src/test/class.ts
@@ -4,7 +4,8 @@ import {
   Intents,
   command,
   CommandContext,
-  Extension
+  Extension,
+  CommandBuilder
 } from '../../mod.ts'
 import { TOKEN } from './config.ts'
 
@@ -21,15 +22,16 @@ class MyClient extends CommandClient {
     console.log(`Logged in as ${this.user?.tag}!`)
   }
 
-  @command({
-    aliases: 'pong'
-  })
+  @command({ aliases: 'pong' })
   Ping(ctx: CommandContext): void {
     ctx.message.reply('Pong!')
   }
 }
 
 class VCExtension extends Extension {
+  name = 'VC'
+  subPrefix = 'vc'
+
   @command()
   async join(ctx: CommandContext): Promise<void> {
     const userVS = await ctx.guild?.voiceStates.get(ctx.author.id)
@@ -58,5 +60,11 @@ class VCExtension extends Extension {
 const client = new MyClient()
 
 client.extensions.load(VCExtension)
+
+client.commands.add(
+  new CommandBuilder()
+    .setName('join')
+    .onExecute((ctx) => ctx.message.reply('haha'))
+)
 
 client.connect(TOKEN, Intents.All)


### PR DESCRIPTION
In this PR, I have added support for two decorators: event and command, and also changed argument parsing method from just split to CLI-like arguments.

## Changes
- Fixed multiple prefix collisions.
  - Reworked prefix handler.
- Added `Command#nsfw` and appropriate checks.
- Implemented sub-prefixes!
  - Sub-prefix can be determined by Extensions.
  - These can greatly help in distinguishing Extension commands from others.
  - These can also serve as a way to make sub commands!

## Decorators

At the moment, decorators are only supported for class and its props/methods. So for using them, user must extend `Client` / `CommandClient`.

### Events

These decorators optionally accept event name when you don't want to keep method name same as the event. And these are applicable in `Client` (and `CommandClient`) and `Extension` too.

```ts
class MyClient extends Client {
  @event()
  ready(): void {
    console.log("I'm ready!")
  }

  // Custom method name
  @event('messageCreate')
  onMessage(msg: Message): void {
    // do something
  }
}

new MyClient().connect(token, intents)
```

### Commands
Similar to events, but command decorator can take CommandOptions (new interface being implemented by Command).
`@command` decorator is applicable to both `CommandClient` and `Extension`.

Examples can be found in `src/test/class.ts`. I didn't add all of them here.

### How it works
Decorators work a bit tricky here, loaded even before default values of a class are serialized! So for that, I added properties like `_decoratedEvents`, `_decoratedCommands` which look for any decorated prop and register (load) them into class and remove.