### PR TITLE
Add Sticker Feature (related to #62)

### DIFF
--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -16,6 +16,7 @@ import { MessageMentions } from './messageMentions.ts'
 import { TextChannel } from './textChannel.ts'
 import { Guild } from './guild.ts'
 import { MessageReactionsManager } from '../managers/messageReactions.ts'
+import { MessageSticker } from './messageSticker.ts'
 
 type AllMessageOptions = MessageOption | Embed
 
@@ -43,6 +44,7 @@ export class Message extends Base {
   application?: MessageApplication
   messageReference?: MessageReference
   flags?: number
+  stickers?: MessageSticker[]
 
   constructor(
     client: Client,
@@ -72,6 +74,12 @@ export class Message extends Base {
     this.messageReference = data.message_reference
     this.flags = data.flags
     this.channel = channel
+    this.stickers =
+      data.stickers !== undefined
+        ? data.stickers.map(
+            (payload) => new MessageSticker(this.client, payload)
+          )
+        : undefined
   }
 
   readFromData(data: MessagePayload): void {
@@ -91,6 +99,12 @@ export class Message extends Base {
     this.application = data.application ?? this.application
     this.messageReference = data.message_reference ?? this.messageReference
     this.flags = data.flags ?? this.flags
+    this.stickers =
+      data.stickers !== undefined
+        ? data.stickers.map(
+            (payload) => new MessageSticker(this.client, payload)
+          )
+        : this.stickers
   }
 
   /** Edits this message. */

--- a/src/structures/messageSticker.ts
+++ b/src/structures/messageSticker.ts
@@ -1,0 +1,43 @@
+import { Client } from '../models/client.ts'
+import {
+  MessageStickerFormatTypes,
+  MessageStickerPayload
+} from '../types/channel.ts'
+import { Base } from './base.ts'
+
+export class MessageSticker extends Base {
+  id: string
+  packID: string
+  name: string
+  description: string
+  tags?: string[]
+  asset: string
+  previewAsset: string | null
+  formatType: MessageStickerFormatTypes
+
+  constructor(client: Client, data: MessageStickerPayload) {
+    super(client)
+
+    this.id = data.id
+    this.packID = data.pack_id
+    this.name = data.name
+    this.description = data.description
+    this.tags = data.tags !== undefined ? data.tags.split(', ') : undefined
+    this.asset = data.asset
+    this.previewAsset = data.preview_asset
+    this.formatType = data.format_type
+  }
+
+  readFromData(data: MessageStickerPayload): void {
+    this.id = data.id ?? this.id
+    this.packID = data.pack_id ?? this.packID
+    this.name = data.name ?? this.name
+    this.description = data.description ?? this.description
+    this.tags = data.tags !== undefined ? data.tags.split(', ') : this.tags
+    this.asset = data.asset ?? this.asset
+    this.previewAsset = data.preview_asset ?? this.previewAsset
+    this.formatType = data.format_type ?? this.formatType
+  }
+
+  // TODO: Make asset url function when it's available
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -14,9 +14,9 @@ import {
 import { TOKEN } from './config.ts'
 
 const client = new Client({
-  clientProperties: {
-    browser: 'Discord iOS'
-  }
+  // clientProperties: {
+  //   browser: 'Discord iOS'
+  // }
   // bot: false,
   // cache: new RedisCacheAdapter({
   //   hostname: '127.0.0.1',
@@ -47,7 +47,15 @@ client.on('channelUpdate', (b: EveryChannelTypes, a: EveryChannelTypes) => {
 
 client.on('messageCreate', async (msg: Message) => {
   if (msg.author.bot === true) return
-  console.log(`${msg.author.tag}: ${msg.content}`)
+  if (msg.stickers !== undefined) {
+    console.log(
+      `${msg.author.tag}: (Sticker)${msg.stickers.map(
+        (sticker) => `Name: ${sticker.name}, Tags: ${sticker.tags}`
+      )}`
+    )
+  } else {
+    console.log(`${msg.author.tag}: ${msg.content}`)
+  }
   if (msg.content === '!ping') {
     msg.reply(`Pong! Ping: ${client.ping}ms`)
   } else if (msg.content === '!members') {

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -96,6 +96,7 @@ export interface MessagePayload {
   application?: MessageApplication
   message_reference?: MessageReference
   flags?: number
+  stickers?: MessageStickerPayload[]
 }
 
 export interface MessageOption {
@@ -255,4 +256,21 @@ export enum MessageFlags {
 export interface FollowedChannel {
   channel_id: string
   webhook_id: string
+}
+
+export enum MessageStickerFormatTypes {
+  PNG = 1,
+  APNG = 2,
+  LOTTIE = 3
+}
+
+export interface MessageStickerPayload {
+  id: string
+  pack_id: string
+  name: string
+  description: string
+  tags?: string
+  asset: string
+  preview_asset: string | null
+  format_type: MessageStickerFormatTypes
 }


### PR DESCRIPTION
This PR adds support for the sticker message and fixes to #62.
Currently, Discord only supports reading stickers (At least for bots).
https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure