### PR TITLE
Quick fix for Events to use Manager#_delete and adding full Invite support

### DIFF
--- a/src/gateway/handlers/channelDelete.ts
+++ b/src/gateway/handlers/channelDelete.ts
@@ -7,7 +7,7 @@ export const channelDelete: GatewayEventHandler = async (
 ) => {
   const channel = await gateway.client.channels.get(d.id)
   if (channel !== undefined) {
-    await gateway.client.channels.delete(d.id)
+    await gateway.client.channels._delete(d.id)
     gateway.client.emit('channelDelete', channel)
   }
 }

--- a/src/gateway/handlers/guildCreate.ts
+++ b/src/gateway/handlers/guildCreate.ts
@@ -30,5 +30,5 @@ export const guildCreate: GatewayEventHandler = async (
   if (hasGuild === undefined) {
     // It wasn't lazy load, so emit event
     gateway.client.emit('guildCreate', guild)
-  }
+  } else gateway.client.emit('guildLoaded', guild)
 }

--- a/src/gateway/handlers/guildDelete.ts
+++ b/src/gateway/handlers/guildDelete.ts
@@ -13,7 +13,7 @@ export const guildDelete: GatewayEventHandler = async (
     await guild.channels.flush()
     await guild.roles.flush()
     await guild.presences.flush()
-    await gateway.client.guilds.delete(d.id)
+    await gateway.client.guilds._delete(d.id)
 
     gateway.client.emit('guildDelete', guild)
   }

--- a/src/gateway/handlers/guildRoleDelete.ts
+++ b/src/gateway/handlers/guildRoleDelete.ts
@@ -13,6 +13,7 @@ export const guildRoleDelete: GatewayEventHandler = async (
   const role = await guild.roles.get(d.role_id)
   // Shouldn't happen either
   if (role === undefined) return
+  await guild.roles._delete(d.role_id)
 
   gateway.client.emit('guildRoleDelete', role)
 }

--- a/src/gateway/handlers/index.ts
+++ b/src/gateway/handlers/index.ts
@@ -155,6 +155,11 @@ export interface ClientEvents {
    */
   guildCreate: [guild: Guild]
   /**
+   * A Guild was successfully loaded.
+   * @param guild The Guild object
+   */
+  guildLoaded: [guild: Guild]
+  /**
    * A Guild in which Client was either deleted, or bot was kicked
    * @param guild The Guild object
    */

--- a/src/gateway/handlers/inviteDelete.ts
+++ b/src/gateway/handlers/inviteDelete.ts
@@ -19,7 +19,6 @@ export const inviteDelete: GatewayEventHandler = async (
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const cachedGuild = await gateway.client.guilds.get(d.guild_id!)
 
-  // TODO(DjDeveloperr): Make it support self-bots and make Guild not always defined
   if (cachedInvite === undefined) {
     const uncachedInvite: PartialInvitePayload = {
       guild: (cachedGuild as unknown) as Guild,
@@ -28,7 +27,7 @@ export const inviteDelete: GatewayEventHandler = async (
     }
     return gateway.client.emit('inviteDeleteUncached', uncachedInvite)
   } else {
-    await guild.invites.delete(d.code)
+    await guild.invites._delete(d.code)
     gateway.client.emit('inviteDelete', cachedInvite)
   }
 }

--- a/src/gateway/handlers/messageDelete.ts
+++ b/src/gateway/handlers/messageDelete.ts
@@ -15,6 +15,6 @@ export const messageDelete: GatewayEventHandler = async (
   const message = await channel.messages.get(d.id)
   if (message === undefined)
     return gateway.client.emit('messageDeleteUncached', d)
-  await channel.messages.delete(d.id)
+  await channel.messages._delete(d.id)
   gateway.client.emit('messageDelete', message)
 }

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -188,7 +188,9 @@ export class Gateway extends EventEmitter {
         this.reconnect()
         break
       case GatewayCloseCodes.UNKNOWN_OPCODE:
-        throw new Error("Unknown OP Code was sent. This shouldn't happen!")
+        throw new Error(
+          "Invalid OP Code or Payload was sent. This shouldn't happen!"
+        )
       case GatewayCloseCodes.DECODE_ERROR:
         throw new Error("Invalid Payload was sent. This shouldn't happen!")
       case GatewayCloseCodes.NOT_AUTHENTICATED:
@@ -320,8 +322,8 @@ export class Gateway extends EventEmitter {
       op: GatewayOpcodes.REQUEST_GUILD_MEMBERS,
       d: {
         guild_id: guild,
-        query: options.query,
-        limit: options.limit,
+        query: options.query ?? '',
+        limit: options.limit ?? 0,
         presences: options.presences,
         user_ids: options.users,
         nonce
@@ -387,14 +389,13 @@ export class Gateway extends EventEmitter {
 
   send(data: GatewayResponse): boolean {
     if (this.websocket.readyState !== this.websocket.OPEN) return false
-    this.websocket.send(
-      JSON.stringify({
-        op: data.op,
-        d: data.d,
-        s: typeof data.s === 'number' ? data.s : null,
-        t: data.t === undefined ? null : data.t
-      })
-    )
+    const packet = JSON.stringify({
+      op: data.op,
+      d: data.d,
+      s: typeof data.s === 'number' ? data.s : null,
+      t: data.t === undefined ? null : data.t
+    })
+    this.websocket.send(packet)
     return true
   }
 

--- a/src/managers/channels.ts
+++ b/src/managers/channels.ts
@@ -29,6 +29,7 @@ export class ChannelsManager extends BaseManager<ChannelPayload, Channel> {
     const arr = await (this.client.cache.array(
       this.cacheName
     ) as ChannelPayload[])
+    if (arr === undefined) return []
     const result: any[] = []
     for (const elem of arr) {
       let guild

--- a/src/managers/guildChannels.ts
+++ b/src/managers/guildChannels.ts
@@ -5,11 +5,14 @@ import { CategoryChannel } from '../structures/guildCategoryChannel.ts'
 import { GuildTextChannel } from '../structures/textChannel.ts'
 import { VoiceChannel } from '../structures/guildVoiceChannel.ts'
 import {
+  ChannelTypes,
   GuildCategoryChannelPayload,
+  GuildChannelPayload,
   GuildTextChannelPayload,
-  GuildVoiceChannelPayload
+  GuildVoiceChannelPayload,
+  Overwrite
 } from '../types/channel.ts'
-import { CHANNEL } from '../types/endpoint.ts'
+import { CHANNEL, GUILD_CHANNELS } from '../types/endpoint.ts'
 import { BaseChildManager } from './baseChild.ts'
 import { ChannelsManager } from './channels.ts'
 
@@ -18,6 +21,19 @@ export type GuildChannelPayloads =
   | GuildVoiceChannelPayload
   | GuildCategoryChannelPayload
 export type GuildChannel = GuildTextChannel | VoiceChannel | CategoryChannel
+
+export interface CreateChannelOptions {
+  name: string
+  type?: ChannelTypes
+  topic?: string
+  bitrate?: number
+  userLimit?: number
+  rateLimitPerUser?: number
+  position?: number
+  permissionOverwrites?: Overwrite[]
+  parent?: CategoryChannel | string
+  nsfw?: boolean
+}
 
 export class GuildChannelsManager extends BaseChildManager<
   GuildChannelPayloads,
@@ -54,5 +70,33 @@ export class GuildChannelsManager extends BaseChildManager<
       this.parent.delete(elem.id)
     }
     return true
+  }
+
+  /** Create a new Guild Channel */
+  async create(options: CreateChannelOptions): Promise<GuildChannel> {
+    if (options.name === undefined)
+      throw new Error('name is required for GuildChannelsManager#create')
+    const res = ((await this.client.rest.post(GUILD_CHANNELS(this.guild.id)),
+    {
+      name: options.name,
+      type: options.type,
+      topic: options.topic,
+      bitrate: options.bitrate,
+      user_limit: options.userLimit,
+      rate_limit_per_user: options.rateLimitPerUser,
+      position: options.position,
+      permission_overwrites: options.permissionOverwrites,
+      parent_id:
+        options.parent === undefined
+          ? undefined
+          : typeof options.parent === 'object'
+          ? options.parent.id
+          : options.parent,
+      nsfw: options.nsfw
+    }) as unknown) as GuildChannelPayload
+
+    await this.set(res.id, res)
+    const channel = await this.get(res.id)
+    return (channel as unknown) as GuildChannel
   }
 }

--- a/src/managers/guildVoiceStates.ts
+++ b/src/managers/guildVoiceStates.ts
@@ -17,6 +17,13 @@ export class GuildVoiceStatesManager extends BaseManager<
     this.guild = guild
   }
 
+  /** Get Client's Voice State in the Guild */
+  async me(): Promise<VoiceState | undefined> {
+    const member = await this.guild.me()
+    return await this.get(member.id)
+  }
+
+  /** Get a Voice State by User ID */
   async get(key: string): Promise<VoiceState | undefined> {
     const raw = await this._get(key)
     if (raw === undefined) return

--- a/src/managers/invites.ts
+++ b/src/managers/invites.ts
@@ -91,7 +91,7 @@ export class InviteManager extends BaseManager<InvitePayload, Invite> {
             : typeof options.targetUser === 'string'
             ? options.targetUser
             : options.targetUser.id,
-        target_user_type: options?.targetUser
+        target_user_type: options?.targetUserType
       }
     )) as unknown) as InvitePayload
 

--- a/src/managers/invites.ts
+++ b/src/managers/invites.ts
@@ -1,9 +1,23 @@
+import { GuildTextChannel, User } from '../../mod.ts'
 import { Client } from '../models/client.ts'
 import { Guild } from '../structures/guild.ts'
 import { Invite } from '../structures/invite.ts'
-import { INVITE } from '../types/endpoint.ts'
+import { CHANNEL_INVITES, GUILD_INVITES, INVITE } from '../types/endpoint.ts'
 import { InvitePayload } from '../types/invite.ts'
 import { BaseManager } from './base.ts'
+
+export enum InviteTargetUserType {
+  STREAM = 1
+}
+
+export interface CreateInviteOptions {
+  maxAge?: number
+  maxUses?: number
+  temporary?: boolean
+  unique?: boolean
+  targetUser?: string | User
+  targetUserType?: InviteTargetUserType
+}
 
 export class InviteManager extends BaseManager<InvitePayload, Invite> {
   guild: Guild
@@ -20,10 +34,10 @@ export class InviteManager extends BaseManager<InvitePayload, Invite> {
   }
 
   /** Fetch an Invite */
-  async fetch(id: string): Promise<Invite> {
+  async fetch(id: string, withCounts: boolean = true): Promise<Invite> {
     return await new Promise((resolve, reject) => {
       this.client.rest
-        .get(INVITE(id))
+        .get(`${INVITE(id)}${withCounts ? '?with_counts=true' : ''}`)
         .then(async (data) => {
           this.set(id, data as InvitePayload)
           const newInvite = await this.get(data.code)
@@ -31,6 +45,57 @@ export class InviteManager extends BaseManager<InvitePayload, Invite> {
         })
         .catch((e) => reject(e))
     })
+  }
+
+  /** Fetch all Invites of a Guild or a specific Channel */
+  async fetchAll(channel?: string | GuildTextChannel): Promise<Invite[]> {
+    const rawInvites = (await this.client.rest.get(
+      channel === undefined
+        ? GUILD_INVITES(this.guild.id)
+        : CHANNEL_INVITES(typeof channel === 'string' ? channel : channel.id)
+    )) as InvitePayload[]
+
+    const res: Invite[] = []
+
+    for (const raw of rawInvites) {
+      await this.set(raw.code, raw)
+      res.push(new Invite(this.client, raw))
+    }
+
+    return res
+  }
+
+  /** Delete an Invite */
+  async delete(invite: string | Invite): Promise<boolean> {
+    await this.client.rest.delete(
+      INVITE(typeof invite === 'string' ? invite : invite.code)
+    )
+    return true
+  }
+
+  /** Create an Invite */
+  async create(
+    channel: string | GuildTextChannel,
+    options?: CreateInviteOptions
+  ): Promise<Invite> {
+    const raw = ((await this.client.rest.post(
+      CHANNEL_INVITES(typeof channel === 'string' ? channel : channel.id),
+      {
+        max_age: options?.maxAge,
+        max_uses: options?.maxUses,
+        temporary: options?.temporary,
+        unique: options?.unique,
+        target_user:
+          options?.targetUser === undefined
+            ? undefined
+            : typeof options.targetUser === 'string'
+            ? options.targetUser
+            : options.targetUser.id,
+        target_user_type: options?.targetUser
+      }
+    )) as unknown) as InvitePayload
+
+    return new Invite(this.client, raw)
   }
 
   async fromPayload(invites: InvitePayload[]): Promise<boolean> {

--- a/src/managers/messageReactions.ts
+++ b/src/managers/messageReactions.ts
@@ -3,8 +3,13 @@ import { Emoji } from '../structures/emoji.ts'
 import { Guild } from '../structures/guild.ts'
 import { Message } from '../structures/message.ts'
 import { MessageReaction } from '../structures/messageReaction.ts'
+import { User } from '../structures/user.ts'
 import { Reaction } from '../types/channel.ts'
-import { MESSAGE_REACTION, MESSAGE_REACTIONS } from '../types/endpoint.ts'
+import {
+  MESSAGE_REACTION,
+  MESSAGE_REACTIONS,
+  MESSAGE_REACTION_USER
+} from '../types/endpoint.ts'
 import { BaseManager } from './base.ts'
 
 export class MessageReactionsManager extends BaseManager<
@@ -74,6 +79,25 @@ export class MessageReactionsManager extends BaseManager<
     )
     await this.client.rest.delete(
       MESSAGE_REACTION(this.message.channel.id, this.message.id, val)
+    )
+    return this
+  }
+
+  /** Remove a specific Emoji from Reactions */
+  async removeUser(
+    emoji: Emoji | string,
+    user: User | string
+  ): Promise<MessageReactionsManager> {
+    const val = encodeURIComponent(
+      (typeof emoji === 'object' ? emoji.id ?? emoji.name : emoji) as string
+    )
+    await this.client.rest.delete(
+      MESSAGE_REACTION_USER(
+        this.message.channel.id,
+        this.message.id,
+        val,
+        typeof user === 'string' ? user : user.id
+      )
     )
     return this
   }

--- a/src/managers/reactionUsers.ts
+++ b/src/managers/reactionUsers.ts
@@ -1,5 +1,6 @@
 import { Client } from '../models/client.ts'
 import { MessageReaction } from '../structures/messageReaction.ts'
+import { User } from '../structures/user.ts'
 import { UsersManager } from './users.ts'
 
 export class ReactionUsersManager extends UsersManager {
@@ -9,5 +10,15 @@ export class ReactionUsersManager extends UsersManager {
     super(client)
     this.cacheName = `reaction_users:${reaction.message.id}`
     this.reaction = reaction
+  }
+
+  /** Remove all Users from this Reaction */
+  async removeAll(): Promise<void> {
+    await this.reaction.message.reactions.removeEmoji(this.reaction.emoji)
+  }
+
+  /** Remove a specific User from this Reaction */
+  async remove(user: User | string): Promise<void> {
+    await this.reaction.message.reactions.removeUser(this.reaction.emoji, user)
   }
 }

--- a/src/models/cacheAdapter.ts
+++ b/src/models/cacheAdapter.ts
@@ -1,9 +1,5 @@
 import { Collection } from '../utils/collection.ts'
-import {
-  connect,
-  Redis,
-  RedisConnectOptions
-} from '../../deps.ts'
+import { connect, Redis, RedisConnectOptions } from '../../deps.ts'
 
 /**
  * ICacheAdapter is the interface to be implemented by Cache Adapters for them to be usable with Harmony.

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -134,7 +134,6 @@ export class Client extends EventEmitter {
     handler: (interaction: Interaction) => any
   }>
 
-  _decoratedSlashModules?: string[]
   _id?: string
 
   /** Shard on which this Client is */
@@ -360,14 +359,5 @@ export function groupslash(
         guild,
         handler: item
       })
-  }
-}
-
-/** Decorator to add a Slash Module to Client */
-export function slashModule() {
-  return function (client: Client | SlashClient, prop: string) {
-    if (client._decoratedSlashModules === undefined)
-      client._decoratedSlashModules = []
-    client._decoratedSlashModules.push(prop)
   }
 }

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -134,7 +134,7 @@ export class Client extends EventEmitter {
     handler: (interaction: Interaction) => any
   }>
 
-  _decoratedSlashModules?: SlashModule[]
+  _decoratedSlashModules?: string[]
   _id?: string
 
   /** Shard on which this Client is */
@@ -291,6 +291,7 @@ export class Client extends EventEmitter {
   }
 }
 
+/** Event decorator to create an Event handler from function */
 export function event(name?: keyof ClientEvents) {
   return function (client: Client | Extension, prop: keyof ClientEvents) {
     const listener = ((client as unknown) as {
@@ -311,7 +312,7 @@ export function slash(name?: string, guild?: string) {
     if (client._decoratedSlash === undefined) client._decoratedSlash = []
     const item = (client as { [name: string]: any })[prop]
     if (typeof item !== 'function') {
-      client._decoratedSlash.push(item)
+      throw new Error('@slash decorator requires a function')
     } else
       client._decoratedSlash.push({
         name: name ?? prop,
@@ -327,8 +328,7 @@ export function subslash(parent: string, name?: string, guild?: string) {
     if (client._decoratedSlash === undefined) client._decoratedSlash = []
     const item = (client as { [name: string]: any })[prop]
     if (typeof item !== 'function') {
-      item.parent = parent
-      client._decoratedSlash.push(item)
+      throw new Error('@subslash decorator requires a function')
     } else
       client._decoratedSlash.push({
         parent,
@@ -350,9 +350,7 @@ export function groupslash(
     if (client._decoratedSlash === undefined) client._decoratedSlash = []
     const item = (client as { [name: string]: any })[prop]
     if (typeof item !== 'function') {
-      item.parent = parent
-      item.group = group
-      client._decoratedSlash.push(item)
+      throw new Error('@groupslash decorator requires a function')
     } else
       client._decoratedSlash.push({
         group,

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -266,6 +266,7 @@ export class Client extends EventEmitter {
     this.gateway = new Gateway(this, token, intents)
   }
 
+  /** Wait for an Event (optionally satisfying an event) to occur */
   async waitFor<K extends keyof ClientEvents>(
     event: K,
     checkFunction: (...args: ClientEvents[K]) => boolean,
@@ -308,7 +309,7 @@ export function event(name?: keyof ClientEvents) {
 
 /** Decorator to create a Slash Command handler */
 export function slash(name?: string, guild?: string) {
-  return function (client: Client | SlashModule, prop: string) {
+  return function (client: Client | SlashClient | SlashModule, prop: string) {
     if (client._decoratedSlash === undefined) client._decoratedSlash = []
     const item = (client as { [name: string]: any })[prop]
     if (typeof item !== 'function') {
@@ -324,7 +325,7 @@ export function slash(name?: string, guild?: string) {
 
 /** Decorator to create a Sub-Slash Command handler */
 export function subslash(parent: string, name?: string, guild?: string) {
-  return function (client: Client | SlashModule, prop: string) {
+  return function (client: Client | SlashModule | SlashClient, prop: string) {
     if (client._decoratedSlash === undefined) client._decoratedSlash = []
     const item = (client as { [name: string]: any })[prop]
     if (typeof item !== 'function') {
@@ -364,7 +365,7 @@ export function groupslash(
 
 /** Decorator to add a Slash Module to Client */
 export function slashModule() {
-  return function (client: Client, prop: string) {
+  return function (client: Client | SlashClient, prop: string) {
     if (client._decoratedSlashModules === undefined)
       client._decoratedSlashModules = []
 

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -368,8 +368,6 @@ export function slashModule() {
   return function (client: Client | SlashClient, prop: string) {
     if (client._decoratedSlashModules === undefined)
       client._decoratedSlashModules = []
-
-    const mod = ((client as unknown) as { [key: string]: any })[prop]
-    client._decoratedSlashModules.push(mod)
+    client._decoratedSlashModules.push(prop)
   }
 }

--- a/src/models/commandClient.ts
+++ b/src/models/commandClient.ts
@@ -382,6 +382,7 @@ export class CommandClient extends Client implements CommandClientOptions {
   }
 }
 
+/** Command decorator */
 export function command(options?: CommandOptions) {
   return function (target: CommandClient | Extension, name: string) {
     if (target._decoratedCommands === undefined) target._decoratedCommands = {}
@@ -390,10 +391,8 @@ export function command(options?: CommandOptions) {
       [name: string]: (ctx: CommandContext) => any
     })[name]
 
-    if (prop instanceof Command) {
-      target._decoratedCommands[prop.name] = prop
-      return
-    }
+    if (typeof prop !== 'function')
+      throw new Error('@command decorator can only be used on functions')
 
     const command = new Command()
 

--- a/src/models/slashClient.ts
+++ b/src/models/slashClient.ts
@@ -353,8 +353,6 @@ export class SlashClient {
     handler: (interaction: Interaction) => any
   }>
 
-  _decoratedSlashModules?: string[]
-
   constructor(options: SlashOptions) {
     let id = options.id
     if (options.token !== undefined) id = atob(options.token?.split('.')[0])
@@ -376,33 +374,9 @@ export class SlashClient {
       })
     }
 
-    if (this.client?._decoratedSlashModules !== undefined) {
-      this.client._decoratedSlashModules.forEach((e) => {
-        const mod = ((this.client as unknown) as {
-          [name: string]: SlashModule
-        })[e]
-        if (!(mod instanceof SlashModule))
-          throw new Error(
-            '@slashModule can only be used on SlashModule instances'
-          )
-        this.modules.push(mod)
-      })
-    }
-
     if (this._decoratedSlash !== undefined) {
       this._decoratedSlash.forEach((e) => {
         this.handlers.push(e)
-      })
-    }
-
-    if (this._decoratedSlashModules !== undefined) {
-      this._decoratedSlashModules.forEach((e) => {
-        const mod = ((this as unknown) as { [name: string]: SlashModule })[e]
-        if (!(mod instanceof SlashModule))
-          throw new Error(
-            '@slashModule can only be used on SlashModule instances'
-          )
-        this.modules.push(mod)
       })
     }
 

--- a/src/models/slashClient.ts
+++ b/src/models/slashClient.ts
@@ -398,10 +398,6 @@ export class SlashClient {
     if (this._decoratedSlashModules !== undefined) {
       this._decoratedSlashModules.forEach((e) => {
         const mod = ((this as unknown) as { [name: string]: SlashModule })[e]
-        if (!(mod instanceof SlashModule))
-          throw new Error(
-            '@slashModule can only be used on SlashModule instances'
-          )
         this.modules.push(mod)
       })
     }

--- a/src/models/slashClient.ts
+++ b/src/models/slashClient.ts
@@ -398,6 +398,10 @@ export class SlashClient {
     if (this._decoratedSlashModules !== undefined) {
       this._decoratedSlashModules.forEach((e) => {
         const mod = ((this as unknown) as { [name: string]: SlashModule })[e]
+        if (!(mod instanceof SlashModule))
+          throw new Error(
+            '@slashModule can only be used on SlashModule instances'
+          )
         this.modules.push(mod)
       })
     }

--- a/src/structures/groupChannel.ts
+++ b/src/structures/groupChannel.ts
@@ -13,8 +13,6 @@ export class GroupDMChannel extends Channel {
     this.name = data.name
     this.icon = data.icon
     this.ownerID = data.owner_id
-    // TODO: Cache in Gateway Event Code
-    // cache.set('groupchannel', this.id, this)
   }
 
   readFromData(data: GroupDMChannelPayload): void {

--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -8,9 +8,13 @@ import {
   IntegrationExpireBehavior
 } from '../types/guild.ts'
 import { Base } from './base.ts'
-import { RolesManager } from '../managers/roles.ts'
+import { CreateGuildRoleOptions, RolesManager } from '../managers/roles.ts'
 import { InviteManager } from '../managers/invites.ts'
-import { GuildChannelsManager } from '../managers/guildChannels.ts'
+import {
+  CreateChannelOptions,
+  GuildChannel,
+  GuildChannelsManager
+} from '../managers/guildChannels.ts'
 import { MembersManager } from '../managers/members.ts'
 import { Role } from './role.ts'
 import { GuildEmojisManager } from '../managers/guildEmojis.ts'
@@ -295,6 +299,16 @@ export class Guild extends Base {
       GUILD_INTEGRATIONS(this.id)
     )) as GuildIntegrationPayload[]
     return raw.map((e) => new GuildIntegration(this.client, e))
+  }
+
+  /** Create a new Guild Channel */
+  async createChannel(options: CreateChannelOptions): Promise<GuildChannel> {
+    return this.channels.create(options)
+  }
+
+  /** Create a new Guild Role */
+  async createRole(options?: CreateGuildRoleOptions): Promise<Role> {
+    return this.roles.create(options)
   }
 
   /**

--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -327,7 +327,6 @@ export class Guild extends Base {
           }
         }, timeout)
       }
-      resolve(this)
     })
   }
 }

--- a/src/structures/invite.ts
+++ b/src/structures/invite.ts
@@ -16,8 +16,30 @@ export class Invite extends Base {
   approximatePresenceCount?: number
   approximateMemberCount?: number
 
+  /** Number of times Invite was used. This is an Invite Metadata property (not always available) */
+  uses?: number
+  /** Max number of times this Invite can be used. This is an Invite Metadata property (not always available) */
+  maxUses?: number
+  /** Max age of the Invite in seconds. This is an Invite Metadata property (not always available) */
+  maxAge?: number
+  /** Whether Invite is temporary or not. This is an Invite Metadata property (not always available) */
+  temporary?: boolean
+  /** Timestamp (string) when Invite was created. This is an Invite Metadata property (not always available) */
+  createdAtTimestamp?: string
+
+  /** Timestamp (Date) when Invite was created. This is an Invite Metadata property (not always available) */
+  get createdAt(): Date | undefined {
+    return this.createdAtTimestamp === undefined
+      ? undefined
+      : new Date(this.createdAtTimestamp)
+  }
+
   get link(): string {
     return `https://discord.gg/${this.code}`
+  }
+
+  toString(): string {
+    return this.link
   }
 
   constructor(client: Client, data: InvitePayload) {
@@ -30,6 +52,12 @@ export class Invite extends Base {
     this.targetUserType = data.target_user_type
     this.approximateMemberCount = data.approximate_member_count
     this.approximatePresenceCount = data.approximate_presence_count
+
+    this.uses = (data as any).uses
+    this.maxUses = (data as any).maxUses
+    this.maxAge = (data as any).maxAge
+    this.temporary = (data as any).temporary
+    this.createdAtTimestamp = (data as any).createdAtTimestamp
   }
 
   /** Delete an invite. Requires the MANAGE_CHANNELS permission on the channel this invite belongs to, or MANAGE_GUILD to remove any invite across the guild. Returns an invite object on success. Fires a Invite Delete Gateway event. */
@@ -49,5 +77,12 @@ export class Invite extends Base {
       data.approximate_member_count ?? this.approximateMemberCount
     this.approximatePresenceCount =
       data.approximate_presence_count ?? this.approximatePresenceCount
+
+    this.uses = (data as any).uses ?? this.uses
+    this.maxUses = (data as any).maxUses ?? this.maxUses
+    this.maxAge = (data as any).maxAge ?? this.maxAge
+    this.temporary = (data as any).temporary ?? this.temporary
+    this.createdAtTimestamp =
+      (data as any).createdAtTimestamp ?? this.createdAtTimestamp
   }
 }

--- a/src/structures/textChannel.ts
+++ b/src/structures/textChannel.ts
@@ -1,3 +1,4 @@
+import { CreateInviteOptions } from '../managers/invites.ts'
 import { MessagesManager } from '../managers/messages.ts'
 import { Client } from '../models/client.ts'
 import {
@@ -22,6 +23,7 @@ import { Channel } from './channel.ts'
 import { Embed } from './embed.ts'
 import { Emoji } from './emoji.ts'
 import { Guild } from './guild.ts'
+import { Invite } from './invite.ts'
 import { Member } from './member.ts'
 import { Message } from './message.ts'
 import { User } from './user.ts'
@@ -318,5 +320,10 @@ export class GuildTextChannel extends TextChannel {
     })
 
     return this
+  }
+
+  /** Create an Invite for this Channel */
+  async createInvite(options?: CreateInviteOptions): Promise<Invite> {
+    return this.guild.invites.create(this.id, options)
   }
 }

--- a/src/test/chunk.ts
+++ b/src/test/chunk.ts
@@ -1,0 +1,24 @@
+import { Client, Intents } from '../../mod.ts'
+import { TOKEN } from './config.ts'
+
+const client = new Client()
+
+client.on('debug', console.log)
+
+client.on('ready', () => {
+  console.log(`Logged in as ${client.user?.tag}!`)
+  client.guilds.get('783319033205751809').then((guild) => {
+    if (guild === undefined) return console.log('Guild not found')
+    guild
+      .chunk({ presences: true }, true)
+      .then((guild) => {
+        console.log(`Chunked guild:`, guild.id)
+      })
+      .catch((e) => {
+        console.log(`Failed to Chunk: ${guild.id} - ${e}`)
+      })
+  })
+})
+
+console.log('Connecting...')
+client.connect(TOKEN, Intents.All)

--- a/src/test/chunk.ts
+++ b/src/test/chunk.ts
@@ -7,17 +7,20 @@ client.on('debug', console.log)
 
 client.on('ready', () => {
   console.log(`Logged in as ${client.user?.tag}!`)
-  client.guilds.get('783319033205751809').then((guild) => {
-    if (guild === undefined) return console.log('Guild not found')
-    guild
-      .chunk({ presences: true }, true)
-      .then((guild) => {
-        console.log(`Chunked guild:`, guild.id)
-      })
-      .catch((e) => {
-        console.log(`Failed to Chunk: ${guild.id} - ${e}`)
-      })
-  })
+})
+
+client.on('guildLoaded', async (guild) => {
+  if (guild.id !== '783319033205751809') return
+  const arr = await guild.channels.array()
+  console.log(arr.length)
+  guild
+    .chunk({ presences: true }, true)
+    .then((guild) => {
+      console.log(`Chunked guild:`, guild.id)
+    })
+    .catch((e) => {
+      console.log(`Failed to Chunk: ${guild.id} - ${e}`)
+    })
 })
 
 console.log('Connecting...')

--- a/src/test/slash-only.ts
+++ b/src/test/slash-only.ts
@@ -1,16 +1,8 @@
 import { SlashClient } from '../models/slashClient.ts'
 import { SlashCommandPartial } from '../types/slash.ts'
 import { TOKEN } from './config.ts'
-import { SlashModule, slashModule } from '../../mod.ts'
 
-class MyMod extends SlashModule {}
-
-class MySlashClient extends SlashClient {
-  @slashModule()
-  mod = new MyMod()
-}
-
-export const slash = new MySlashClient({ token: TOKEN })
+export const slash = new SlashClient({ token: TOKEN })
 
 console.log(slash.modules)
 

--- a/src/test/slash-only.ts
+++ b/src/test/slash-only.ts
@@ -1,8 +1,18 @@
 import { SlashClient } from '../models/slashClient.ts'
 import { SlashCommandPartial } from '../types/slash.ts'
 import { TOKEN } from './config.ts'
+import { SlashModule, slashModule } from '../../mod.ts'
 
-export const slash = new SlashClient({ token: TOKEN })
+class MyMod extends SlashModule {}
+
+class MySlashClient extends SlashClient {
+  @slashModule()
+  mod = new MyMod()
+}
+
+export const slash = new MySlashClient({ token: TOKEN })
+
+console.log(slash.modules)
 
 // Cmd objects come here
 const commands: SlashCommandPartial[] = []

--- a/src/types/endpoint.ts
+++ b/src/types/endpoint.ts
@@ -32,7 +32,7 @@ const GUILD_BANS = (guildID: string): string =>
   `${DISCORD_API_URL}/v${DISCORD_API_VERSION}/guilds/${guildID}/bans`
 const GUILD_CHANNEL = (channelID: string): string =>
   `${DISCORD_API_URL}/v${DISCORD_API_VERSION}/channels/${channelID}`
-const GUILD_CHANNELS = (guildID: string, channelID: string): string =>
+const GUILD_CHANNELS = (guildID: string): string =>
   `${DISCORD_API_URL}/v${DISCORD_API_VERSION}/guilds/${guildID}/channels`
 const GUILD_MEMBER = (guildID: string, memberID: string): string =>
   `${DISCORD_API_URL}/v${DISCORD_API_VERSION}/guilds/${guildID}/members/${memberID}`


### PR DESCRIPTION
This PR introduces following changes,
- \*\_DELETE events now use Manager#_delete to avoid making REST API calls through some Managers (not any atm, but in future)
- Full Invite support added - create, delete, fetch Invites.
- Added a lot of more missing REST Methods to interact with API.
- Fixed Guild#chunk
- New event: guildLoaded
- Fixed GuildChannelsManager#array
- Fixed some more things.